### PR TITLE
feat: add wide table exmaple

### DIFF
--- a/models/example/wide_table/README.md
+++ b/models/example/wide_table/README.md
@@ -1,0 +1,66 @@
+# Wide Table Example using Table Sinks
+
+This is the exact example from RisingWave documentation for maintaining wide tables with table sinks using multiple sinks with the same primary key.
+
+## Overview
+
+Instead of using expensive JOIN operations, this approach creates multiple sinks that feed data into a single wide table. The table uses `ON CONFLICT DO UPDATE IF NOT NULL` to merge data from different sources efficiently.
+
+## Architecture
+
+```
+d1 (v1, k) ──┐
+             ├──► wide_d (v1, v2, v3, k)
+d2 (v2, k) ──┤
+             └──► (merged via table sinks)
+d3 (v3, k) ──┘
+```
+
+## Files Structure
+
+- `d1.sql` - Source table with v1 and primary key k
+- `d2.sql` - Source table with v2 and primary key k  
+- `d3.sql` - Source table with v3 and primary key k
+- `wide_d.sql` - Target wide table with conflict resolution
+- `sink1.sql` - Sink feeding d1 data to wide_d
+- `sink2.sql` - Sink feeding d2 data to wide_d
+- `sink3.sql` - Sink feeding d3 data to wide_d
+
+## Usage
+
+1. Deploy all tables first (source tables and wide table):
+```bash
+dbt run --models d1 d2 d3 wide_d
+```
+
+2. Deploy the sinks to start feeding data into the wide table:
+```bash
+dbt run --models sink1 sink2 sink3
+```
+
+Or deploy everything at once:
+```bash
+dbt run --models tag:wide_table_example
+```
+
+3. The wide table will be populated automatically by the three sinks:
+   - Each sink is configured as `append-only` with `force_append_only = 'true'`
+   - The wide table uses `ON CONFLICT DO UPDATE IF NOT NULL` to merge data
+   - Data is combined using `k` as the primary key
+
+## Key Features
+
+- **Efficient Data Combination**: Avoids expensive streaming joins
+- **Conflict Resolution**: Uses `ON CONFLICT DO UPDATE IF NOT NULL` for safe merging
+- **Append-Only Sinks**: Prevents accidental data deletion
+- **Real-time Updates**: Changes in source tables automatically propagate to the wide table
+
+## Query the Wide Table
+
+```sql
+SELECT v1, v2, v3, k 
+FROM {{ ref('wide_d') }}
+WHERE v1 IS NOT NULL 
+  AND v2 IS NOT NULL 
+  AND v3 IS NOT NULL
+```

--- a/models/example/wide_table/d1.sql
+++ b/models/example/wide_table/d1.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='table_with_connector', tags=['wide_table_example']) }}
+
+CREATE TABLE {{ this }} (
+    v1 int, 
+    k int primary key
+)

--- a/models/example/wide_table/d2.sql
+++ b/models/example/wide_table/d2.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='table_with_connector', tags=['wide_table_example']) }}
+
+CREATE TABLE {{ this }} (
+    v2 int, 
+    k int primary key
+)

--- a/models/example/wide_table/d3.sql
+++ b/models/example/wide_table/d3.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='table_with_connector', tags=['wide_table_example']) }}
+
+CREATE TABLE {{ this }} (
+    v3 int, 
+    k int primary key
+)

--- a/models/example/wide_table/sink1.sql
+++ b/models/example/wide_table/sink1.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='sink', tags=['wide_table_example']) }}
+
+CREATE SINK {{ this }} INTO {{ ref('wide_d') }} (v1, k) AS
+SELECT v1, k FROM {{ ref('d1') }}
+WITH (
+    type = 'append-only',
+    force_append_only = 'true'
+)

--- a/models/example/wide_table/sink2.sql
+++ b/models/example/wide_table/sink2.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='sink', tags=['wide_table_example']) }}
+
+CREATE SINK {{ this }} INTO {{ ref('wide_d') }} (v2, k) AS
+SELECT v2, k FROM {{ ref('d2') }}
+WITH (
+    type = 'append-only',
+    force_append_only = 'true'
+)

--- a/models/example/wide_table/sink3.sql
+++ b/models/example/wide_table/sink3.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='sink', tags=['wide_table_example']) }}
+
+CREATE SINK {{ this }} INTO {{ ref('wide_d') }} (v3, k) AS
+SELECT v3, k FROM {{ ref('d3') }}
+WITH (
+    type = 'append-only',
+    force_append_only = 'true'
+)

--- a/models/example/wide_table/wide_d.sql
+++ b/models/example/wide_table/wide_d.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='table_with_connector', tags=['wide_table_example']) }}
+
+CREATE TABLE {{ this }} (
+    v1 int, 
+    v2 int, 
+    v3 int, 
+    k int primary key
+) ON CONFLICT DO UPDATE IF NOT NULL


### PR DESCRIPTION
This pull request introduces a new example for efficiently maintaining wide tables using multiple table sinks, based on the RisingWave documentation. The implementation demonstrates how to combine data from several source tables into a single wide table, using append-only sinks and conflict resolution to avoid expensive joins and ensure safe, real-time updates.

**Wide Table Example Implementation:**

* Added a comprehensive `README.md` explaining the architecture, file structure, usage, and key features of the wide table example.

**Source Tables and Wide Table Definition:**

* Created three source tables (`d1.sql`, `d2.sql`, `d3.sql`) with distinct value columns (`v1`, `v2`, `v3`) and a shared primary key `k`. [[1]](diffhunk://#diff-864736c0a1ecda4cab99809594d0e1d631ce031de10b4813c69f4c9a3e84c9f4R1-R6) [[2]](diffhunk://#diff-3d6e07ce0b5a56de6dd62c3b18e9c3a0b9e44865cee371188207368265562894R1-R6) [[3]](diffhunk://#diff-92ae90a6ae71256209a2b06b1dae842f65007ce0f63287888069fb61130b969eR1-R6)
* Defined the wide table (`wide_d.sql`) with columns for all three values and the shared primary key, using `ON CONFLICT DO UPDATE IF NOT NULL` for conflict resolution.

**Sink Configuration for Data Ingestion:**

* Added three sink models (`sink1.sql`, `sink2.sql`, `sink3.sql`) to feed data from each source table into the wide table, configured as append-only with forced append-only mode for safe merging. [[1]](diffhunk://#diff-b499eb222db33784bf51677b34cea9b69edb473c943c9d5a9cd4362df135b741R1-R8) [[2]](diffhunk://#diff-83d19832695f7450c9fec86f6999f9a5bfb3290992a9cbea8fd98179195d277aR1-R8) [[3]](diffhunk://#diff-08dc4adc517da65861ed298da69d351f21dad3e710b8600ecd9a2110366f870aR1-R8)